### PR TITLE
Mark as dead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 origami-migration-guru
 =======================
 
-**Origami Migration Guru is experimental.**
+**Deprecated**: origami-migration-guru started as a 10% time project. It was useful during the [2019 major cascade](https://origami.ft.com/blog/2019/10/31/major-cascade/) but is not easy to use, for example requiring a list of all manifest files, and is not 100% reliable. It needs more work and has therefore been deprecated.
 
 Origami Migration Guru helps plan the migration for new major released of components or other projects. For a given project, it analyses a given set of repository manifests looking for dependents. The dependents may be shown as a graph or step by step in an interactive command line interface.
 

--- a/origami.json
+++ b/origami.json
@@ -6,7 +6,7 @@
         "origami"
     ],
     "support": "https://github.com/Financial-Times/origami-migration-guru/issues",
-    "supportStatus": "experimental",
+    "supportStatus": "dead",
     "supportContact": {
         "email": "origami.support@ft.com",
         "slack": "financialtimes/ft-origami"


### PR DESCRIPTION
origami-migration-guru started as a 10% time project. It was
useful during the [2019 major cascade](https://origami.ft.com/blog/2019/10/31/major-cascade/) but is not easy to use, 
for example requiring a list of all manifest files, and is not 100% 
reliable. It needs more work and has therefore been marked as dead.

Note "deprecated" is mentioned in the README because "dead" sounds
so... harsh.